### PR TITLE
Partition [wip]

### DIFF
--- a/src/simple_statistics.js
+++ b/src/simple_statistics.js
@@ -666,6 +666,23 @@
         return output;
     }
 
+    // # partition
+    //
+    function partition(sample, chunks) {
+
+        // `chunks` must be zero or higher - we can't partition a non-zero
+        // list into zero parts.
+        // So, we'll detect and return null in that case to indicate
+        // invalid input.
+        if (chunks <= 0) {
+            return null;
+        }
+
+        var chunkSize = Math.ceil(sample.length / chunks);
+
+        return chunk(sample, chunkSize);
+    }
+
     // # quantile
     //
     // This is a population quantile, since we assume to know the entire
@@ -1410,6 +1427,7 @@
     ss.mad = mad;
 
     ss.chunk = chunk;
+    ss.partition = partition;
 
     ss.sample_covariance = sample_covariance;
     ss.sample_correlation = sample_correlation;


### PR DESCRIPTION
Right now this falls into a fairly serious problem - if you have an
array of length=4 and want 3 chunks, it's not possible to get 3 chunks
with the `chunk()` underlying function, since the input must be integer,
1 will give 4 and 2 will give 2.

So, we either need to change the expectation for the function, saying
that it will _aim_ for the desired number of partitions, or not use
`chunk()` under this.