### PR TITLE
implement a simple perceptron classifier

### DIFF
--- a/src/simple_statistics.js
+++ b/src/simple_statistics.js
@@ -276,7 +276,7 @@
         perceptron_model.predict = function(features) {
             // Only predict if previously trained
             // on the same size feature array(s).
-            if (features.length != w.length) return null;
+            if (features.length !== w.length) return null;
             // Calculate the sum of features times weights,
             // with the bias added (implicitly times one).
             var score = 0;
@@ -285,7 +285,7 @@
             }
             score += b;
             // Classify as 1 if the score is over 0, otherwise 0.
-            return 0 < score ? 1 : 0;
+            return score > 0 ? 1 : 0;
         };
 
         // ## Train
@@ -293,20 +293,20 @@
         // a numeric array of features and a 0 or 1 label.
         perceptron_model.train = function(features, label) {
             // Require that only labels of 0 or 1 are considered.
-            if (label != 0 && label != 1) return null;
+            if (label !== 0 && label !== 1) return null;
             // The length of the feature array determines
             // the length of the weight array.
             // The perceptron will continue learning as long as
             // it keeps seeing feature arrays of the same length.
             // When it sees a new data shape, it initializes.
-            if (features.length != w.length) {
+            if (features.length !== w.length) {
                 w = features;
                 b = 1;
             }
             // Make a prediction based on current weights.
             var prediction = perceptron_model.predict(features);
             // Update the weights if the prediction is wrong.
-            if (prediction != label) {
+            if (prediction !== label) {
                 var gradient = label - prediction;
                 for (var i = 0; i < w.length; i++) {
                     w[i] += gradient * features[i];
@@ -1245,7 +1245,7 @@
     // So, for example, probit(0.5 + 0.6827/2) ≈ 1 because 68.27% of values are
     // normally found within 1 standard deviation above or below the mean.
     function probit(p) {
-        if (p == 0) {
+        if (p === 0) {
             p = epsilon;
         } else if (p >= 1) {
             p = 1 - epsilon;

--- a/src/simple_statistics.js
+++ b/src/simple_statistics.js
@@ -264,11 +264,11 @@
         var perceptron_model = {},
             // The weights, or coefficients of the model;
             // weights are only populated when training with data.
-            w = [],
+            weights = [],
             // The bias term, or intercept; it is also a weight but
             // it's stored separately for convenience as it is always
             // multiplied by one.
-            b = 0;
+            bias = 0;
 
         // ## Predict
         // Use an array of features with the weight array and bias
@@ -276,14 +276,14 @@
         perceptron_model.predict = function(features) {
             // Only predict if previously trained
             // on the same size feature array(s).
-            if (features.length !== w.length) return null;
+            if (features.length !== weights.length) return null;
             // Calculate the sum of features times weights,
             // with the bias added (implicitly times one).
             var score = 0;
-            for (var i = 0; i < w.length; i++) {
-                score += w[i] * features[i];
+            for (var i = 0; i < weights.length; i++) {
+                score += weights[i] * features[i];
             }
-            score += b;
+            score += bias;
             // Classify as 1 if the score is over 0, otherwise 0.
             return score > 0 ? 1 : 0;
         };
@@ -299,31 +299,31 @@
             // The perceptron will continue learning as long as
             // it keeps seeing feature arrays of the same length.
             // When it sees a new data shape, it initializes.
-            if (features.length !== w.length) {
-                w = features;
-                b = 1;
+            if (features.length !== weights.length) {
+                weights = features;
+                bias = 1;
             }
             // Make a prediction based on current weights.
             var prediction = perceptron_model.predict(features);
             // Update the weights if the prediction is wrong.
             if (prediction !== label) {
                 var gradient = label - prediction;
-                for (var i = 0; i < w.length; i++) {
-                    w[i] += gradient * features[i];
+                for (var i = 0; i < weights.length; i++) {
+                    weights[i] += gradient * features[i];
                 }
-                b += gradient;
+                bias += gradient;
             }
             return perceptron_model;
         };
 
-        // Conveniently access the weight array.
-        perceptron_model.w = function() {
-            return w;
+        // Conveniently access the weights array.
+        perceptron_model.weights = function() {
+            return weights;
         };
 
         // Conveniently access the bias.
-        perceptron_model.b = function() {
-            return b;
+        perceptron_model.bias = function() {
+            return bias;
         };
 
         // Return the completed model.

--- a/src/simple_statistics.js
+++ b/src/simple_statistics.js
@@ -1235,6 +1235,10 @@
         }
     }
 
+    // We use `ε`, epsilon, as a stopping criterion when we want to iterate
+    // until we're "close enough".
+    var epsilon = 0.0001;
+
     // # [Probit](http://en.wikipedia.org/wiki/Probit)
     //
     // This is the inverse of cumulative_std_normal_probability(),
@@ -1302,10 +1306,6 @@
     function z_score(x, mean, standard_deviation) {
         return (x - mean) / standard_deviation;
     }
-
-    // We use `ε`, epsilon, as a stopping criterion when we want to iterate
-    // until we're "close enough".
-    var epsilon = 0.0001;
 
     // # [Factorial](https://en.wikipedia.org/wiki/Factorial)
     //

--- a/src/simple_statistics.js
+++ b/src/simple_statistics.js
@@ -254,6 +254,83 @@
         return bayes_model;
     }
 
+
+    // # [Perceptron Classifier](http://en.wikipedia.org/wiki/Perceptron)
+    //
+    // This is a single-layer perceptron classifier that takes
+    // arrays of numbers and predicts whether they should be classified
+    // as either 0 or 1 (negative or positive examples).
+    function perceptron() {
+        var perceptron_model = {},
+            // The weights, or coefficients of the model;
+            // weights are only populated when training with data.
+            w = [],
+            // The bias term, or intercept; it is also a weight but
+            // it's stored separately for convenience as it is always
+            // multiplied by one.
+            b = 0;
+
+        // ## Predict
+        // Use an array of features with the weight array and bias
+        // to predict whether an example is labeled 0 or 1.
+        perceptron_model.predict = function(features) {
+            // Only predict if previously trained
+            // on the same size feature array(s).
+            if (features.length != w.length) return null;
+            // Calculate the sum of features times weights,
+            // with the bias added (implicitly times one).
+            var score = 0;
+            for (var i = 0; i < w.length; i++) {
+                score += w[i] * features[i];
+            }
+            score += b;
+            // Classify as 1 if the score is over 0, otherwise 0.
+            return 0 < score ? 1 : 0;
+        };
+
+        // ## Train
+        // Train the classifier with a new example, which is
+        // a numeric array of features and a 0 or 1 label.
+        perceptron_model.train = function(features, label) {
+            // Require that only labels of 0 or 1 are considered.
+            if (label != 0 && label != 1) return null;
+            // The length of the feature array determines
+            // the length of the weight array.
+            // The perceptron will continue learning as long as
+            // it keeps seeing feature arrays of the same length.
+            // When it sees a new data shape, it initializes.
+            if (features.length != w.length) {
+                w = features;
+                b = 1;
+            }
+            // Make a prediction based on current weights.
+            var prediction = perceptron_model.predict(features);
+            // Update the weights if the prediction is wrong.
+            if (prediction != label) {
+                var gradient = label - prediction;
+                for (var i = 0; i < w.length; i++) {
+                    w[i] += gradient * features[i];
+                }
+                b += gradient;
+            }
+            return perceptron_model;
+        };
+
+        // Conveniently access the weight array.
+        perceptron_model.w = function() {
+            return w;
+        };
+
+        // Conveniently access the bias.
+        perceptron_model.b = function() {
+            return b;
+        };
+
+        // Return the completed model.
+        return perceptron_model;
+    }
+
+
     // # sum
     //
     // is simply the result of adding all numbers
@@ -1589,6 +1666,8 @@
     ss.jenks = jenks;
 
     ss.bayesian = bayesian;
+
+    ss.perceptron = perceptron;
 
     // Distribution-related methods
     ss.epsilon = epsilon; // We make ε available to the test suite.

--- a/test/perceptron.test.js
+++ b/test/perceptron.test.js
@@ -1,0 +1,47 @@
+var ss = require('../');
+var test = require('tape');
+
+test('perceptron', function(t) {
+    test('initializes to zeros if label is zero', function(t) {
+        var p = ss.perceptron();
+        p.train([1, 2, 3], 0);
+        t.deepEqual(p.w(), [0, 0, 0]);
+        t.equal(p.b(), 0);
+        t.end();
+    });
+
+    test('initializes to values if label is one', function(t) {
+        var p = ss.perceptron();
+        p.train([1, 2, 3], 1);
+        t.deepEqual(p.w(), [1, 2, 3]);
+        t.equal(p.b(), 1);
+        t.end();
+    });
+
+    test('learns to separate one from two', function(t) {
+        var p = ss.perceptron();
+        for (var i = 0; i < 4; i++) {
+            p.train([1], 0);
+            p.train([2], 1);
+        }
+        t.equal(p.predict([1]), 0);
+        t.equal(p.predict([2]), 1);
+        t.end();
+    });
+
+    test('learns a diagonal boundary', function(t) {
+        var p = ss.perceptron();
+        for (var i = 0; i < 5; i++) {
+            p.train([1, 1], 1);
+            p.train([0, 1], 0);
+            p.train([1, 0], 0);
+            p.train([0, 0], 0);
+        }
+        t.equal(p.predict([0, 0]), 0);
+        t.equal(p.predict([0, 1]), 0);
+        t.equal(p.predict([1, 0]), 0);
+        t.equal(p.predict([1, 1]), 1);
+        t.end();
+    });
+    t.end();
+});

--- a/test/perceptron.test.js
+++ b/test/perceptron.test.js
@@ -5,16 +5,16 @@ test('perceptron', function(t) {
     test('initializes to zeros if label is zero', function(t) {
         var p = ss.perceptron();
         p.train([1, 2, 3], 0);
-        t.deepEqual(p.w(), [0, 0, 0]);
-        t.equal(p.b(), 0);
+        t.deepEqual(p.weights(), [0, 0, 0]);
+        t.equal(p.bias(), 0);
         t.end();
     });
 
     test('initializes to values if label is one', function(t) {
         var p = ss.perceptron();
         p.train([1, 2, 3], 1);
-        t.deepEqual(p.w(), [1, 2, 3]);
-        t.equal(p.b(), 1);
+        t.deepEqual(p.weights(), [1, 2, 3]);
+        t.equal(p.bias(), 1);
         t.end();
     });
 


### PR DESCRIPTION
This adds `.perceptron()` for making a single-layer perceptron classifier with `.train()` and `.predict()` methods. Tests are in `perceptron.test.js`.

I haven't added anything to the README etc., but if this looks good that could also be done.